### PR TITLE
ci: 新增 Cypress 驗證流程

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Hello GitHub Actions!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,11 @@ jobs:
             node_modules
             ~/.cache/Cypress # needed for the Cypress binary
           key: npm-dependencies-${{ hashFiles('pnpm-lock.yaml') }}
-      - name: 建構 backstage 專案
-        run: pnpm nx build backstage
+      - name: 執行 nx-set-shas 使 nx affected 可以正確判斷 PR 有哪些變更
+        uses: nrwl/nx-set-shas@v3
+      - run: git branch --track main origin/main
+        if: ${{ github.event_name == 'pull_request' }}
+      - name: 更動的部分重新 build 專案
+        run: pnpm nx affected -t build --parallel=1
+      - name: 更動的部分重新 E2E 測試專案
+        run: pnpm nx affected -t e2e --parallel=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,14 @@ jobs:
         with:
           path: |
             node_modules
-            ~/.cache/Cypress # needed for the Cypress binary
           key: npm-dependencies-${{ hashFiles('pnpm-lock.yaml') }}
+      - name: 回復快取過的 Cypress binary
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            cypress-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
       - name: 安裝依賴套件
         run: pnpm install --frozen-lockfile
       - name: 快取依賴套件
@@ -31,8 +37,14 @@ jobs:
         with:
           path: |
             node_modules
-            ~/.cache/Cypress # needed for the Cypress binary
           key: npm-dependencies-${{ hashFiles('pnpm-lock.yaml') }}
+      - name: 儲存當前 Cypress binary 於快取中
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            cypress-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
       - name: 執行 nx-set-shas 使 nx affected 可以正確判斷 PR 有哪些變更
         uses: nrwl/nx-set-shas@v3
       - run: git branch --track main origin/main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,21 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 8
+      - name: 回復快取過的依賴套件
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            node_modules
+            ~/.cache/Cypress # needed for the Cypress binary
+          key: npm-dependencies-${{ hashFiles('pnpm-lock.yaml') }}
       - name: 安裝依賴套件
         run: pnpm install --frozen-lockfile
+      - name: 快取依賴套件
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            node_modules
+            ~/.cache/Cypress # needed for the Cypress binary
+          key: npm-dependencies-${{ hashFiles('pnpm-lock.yaml') }}
       - name: 建構 backstage 專案
         run: pnpm nx build backstage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,4 +52,4 @@ jobs:
       - name: 更動的部分重新 build 專案
         run: pnpm nx affected -t build --parallel=1
       - name: 更動的部分重新 E2E 測試專案
-        run: pnpm nx affected -t e2e --parallel=1
+        run: pnpm nx affected -t e2e-ci --parallel=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,4 +9,15 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Hello GitHub Actions!"
+      - name: 初始化倉庫
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: 安裝 pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - name: 安裝依賴套件
+        run: pnpm install --frozen-lockfile
+      - name: 建構 backstage 專案
+        run: pnpm nx build backstage

--- a/nx.json
+++ b/nx.json
@@ -13,7 +13,9 @@
       "!{projectRoot}/**/*.cy.[jt]s?(x)",
       "!{projectRoot}/cypress.config.[jt]s"
     ],
-    "sharedGlobals": []
+    "sharedGlobals": [
+      "{workspaceRoot}/.github/workflows/ci.yml" 
+    ]
   },
   "plugins": [
     {


### PR DESCRIPTION
根據[官方教學](https://nx.dev/ci/intro/tutorials/github-actions#optimize-our-ci-by-caching-npm-dependencies)設置 NX 於 CI
- [Cypress 快取](https://nx.dev/ci/intro/tutorials/github-actions#optimize-our-ci-by-caching-npm-dependencies)就算照貼也是無法運作的，需要另找方法 > 最終是採用與快取 `node_moduels` 的方式一樣去快取 cypress binrary